### PR TITLE
Grammar fix in use.html: “policy needs”

### DIFF
--- a/use.html
+++ b/use.html
@@ -35,7 +35,7 @@
       <p>Our <dfn>agent</dfn> is {e.g. "Able Agent, 123 Main Street, Oakland, CA 12345, agent@example.com, 555-555-5555"}.</p>
     </blockquote>
     <p>The first paragraph uses a legal technique called <a href="https://en.wikipedia.org/wiki/Incorporation_by_reference">incorporation by reference</a>.</p>
-    <p>The later paragraphs provide information that the policy need to work.</p>
+    <p>The later paragraphs provide information that the policy needs to work.</p>
   </main>
   <footer role="contentinfo">
     <p>a <a href="https://stonecutters.law">Stonecutters</a> project</p>


### PR DESCRIPTION
Perhaps this error came about from copying the phrase “terms need to work” from https://turnstiletos.com/use.